### PR TITLE
Fix the password reset url

### DIFF
--- a/server/auth/generateForgetPasswordHtml.js
+++ b/server/auth/generateForgetPasswordHtml.js
@@ -419,7 +419,7 @@ module.exports = (inProduction, token) => `<!DOCTYPE html>
 
                                             <a href="https://${
                                               inProduction
-                                                ? "collaborate.thebkp.com"
+                                                ? "thebkp.com"
                                                 : "localhost:8000"
                                             }/reset-password/${token}"
                                               target="_blank">Reset your password


### PR DESCRIPTION
This updates the password reset url to match thebkp.com root (previously it was collaborate.thebkp.com)
